### PR TITLE
Use optional client output location when it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,5 +118,5 @@ console.log(fakeProfileComplete());
 
 <sup><sub>Inspired by https://github.com/toyamarinyon/prisma-factory-generator</sub></sup>
 
-<sup><sub>This generator was bootstraped using [create-prisma-generator](https://github.com/YassinEldeeb/create-prisma-generator)
+<sup><sub>This generator was bootstrapped using [create-prisma-generator](https://github.com/YassinEldeeb/create-prisma-generator)
 </sub></sup>

--- a/src/__tests__/__snapshots__/createMethods.test.ts.snap
+++ b/src/__tests__/__snapshots__/createMethods.test.ts.snap
@@ -100,6 +100,206 @@ export function fakeUser2RelationComplete() {
 "
 `;
 
+exports[`createMethods with custom clientImportPath 1`] = `
+"import { Enum } from './src/generated/client';
+import { faker } from '@faker-js/faker';
+
+
+
+export function fakeUser() {
+  return {
+    email: faker.internet.email(),
+    name: faker.person.fullName(),
+    age: faker.number.int({min: 0, max: 99}),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    string: faker.lorem.words(5),
+    nullableString: null,
+    boolean: faker.datatype.boolean(),
+    nullableBoolean: null,
+    int: faker.number.int(),
+    nullableInt: null,
+    bigInt: faker.number.int(),
+    nullableBigInt: null,
+    float: faker.number.float(),
+    nullableFloat: null,
+    dateTime: faker.date.anytime(),
+    nullableDateTime: null,
+    stringArray: faker.lorem.words(5).split(' '),
+    intArray: [faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int()],
+    bigIntArray: [faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int()],
+    floatArray: [faker.number.float(),faker.number.float(),faker.number.float(),faker.number.float(),faker.number.float()],
+    booleanArray: [faker.datatype.boolean(),faker.datatype.boolean(),faker.datatype.boolean(),faker.datatype.boolean(),faker.datatype.boolean()],
+    dateTimeArray: [faker.date.anytime(),faker.date.anytime(),faker.date.anytime(),faker.date.anytime(),faker.date.anytime()],
+    json: {test: faker.lorem.word()},
+    nullableJson: null,
+    enum: faker.helpers.arrayElement([Enum.A, Enum.B, Enum.C] as const),
+    nullableEnum: null,
+  };
+}
+export function fakeUserComplete() {
+  return {
+    id: faker.string.uuid(),
+    email: faker.internet.email(),
+    name: faker.person.fullName(),
+    age: faker.number.int({min: 0, max: 99}),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    string: faker.lorem.words(5),
+    stringWithDefault: 'default',
+    nullableString: null,
+    boolean: faker.datatype.boolean(),
+    booleanWithDefault: true,
+    nullableBoolean: null,
+    int: faker.number.int(),
+    intWithDefault: 1,
+    nullableInt: null,
+    bigInt: faker.number.int(),
+    bigIntWithDefault: 1,
+    nullableBigInt: null,
+    float: faker.number.float(),
+    floatWithDefault: 1.1,
+    nullableFloat: null,
+    dateTime: faker.date.anytime(),
+    dateTimeWithDefault: new Date(),
+    nullableDateTime: null,
+    stringArray: faker.lorem.words(5).split(' '),
+    intArray: [faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int()],
+    bigIntArray: [faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int()],
+    floatArray: [faker.number.float(),faker.number.float(),faker.number.float(),faker.number.float(),faker.number.float()],
+    booleanArray: [faker.datatype.boolean(),faker.datatype.boolean(),faker.datatype.boolean(),faker.datatype.boolean(),faker.datatype.boolean()],
+    dateTimeArray: [faker.date.anytime(),faker.date.anytime(),faker.date.anytime(),faker.date.anytime(),faker.date.anytime()],
+    json: {test: faker.lorem.word()},
+    jsonWithDefault: {},
+    jsonWithDefaultAndFake: {test2: faker.lorem.word()},
+    nullableJson: null,
+    enum: faker.helpers.arrayElement([Enum.A, Enum.B, Enum.C] as const),
+    enumWithDefault: Enum.A,
+    nullableEnum: null,
+    enums: [Enum.A],
+  };
+}
+export function fakeUser2Complete() {
+  return {
+    id: faker.number.int(),
+  };
+}
+export function fakeUserRelationComplete() {
+  return {
+    id: faker.string.uuid(),
+    userId: faker.string.uuid(),
+    userId2: faker.string.uuid(),
+  };
+}
+export function fakeUser2RelationComplete() {
+  return {
+    id: faker.string.uuid(),
+    user2Id: faker.number.int(),
+  };
+}
+"
+`;
+
+exports[`createMethods with default clientImportPath 1`] = `
+"import { Enum } from '@prisma/client';
+import { faker } from '@faker-js/faker';
+
+
+
+export function fakeUser() {
+  return {
+    email: faker.internet.email(),
+    name: faker.person.fullName(),
+    age: faker.number.int({min: 0, max: 99}),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    string: faker.lorem.words(5),
+    nullableString: null,
+    boolean: faker.datatype.boolean(),
+    nullableBoolean: null,
+    int: faker.number.int(),
+    nullableInt: null,
+    bigInt: faker.number.int(),
+    nullableBigInt: null,
+    float: faker.number.float(),
+    nullableFloat: null,
+    dateTime: faker.date.anytime(),
+    nullableDateTime: null,
+    stringArray: faker.lorem.words(5).split(' '),
+    intArray: [faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int()],
+    bigIntArray: [faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int()],
+    floatArray: [faker.number.float(),faker.number.float(),faker.number.float(),faker.number.float(),faker.number.float()],
+    booleanArray: [faker.datatype.boolean(),faker.datatype.boolean(),faker.datatype.boolean(),faker.datatype.boolean(),faker.datatype.boolean()],
+    dateTimeArray: [faker.date.anytime(),faker.date.anytime(),faker.date.anytime(),faker.date.anytime(),faker.date.anytime()],
+    json: {test: faker.lorem.word()},
+    nullableJson: null,
+    enum: faker.helpers.arrayElement([Enum.A, Enum.B, Enum.C] as const),
+    nullableEnum: null,
+  };
+}
+export function fakeUserComplete() {
+  return {
+    id: faker.string.uuid(),
+    email: faker.internet.email(),
+    name: faker.person.fullName(),
+    age: faker.number.int({min: 0, max: 99}),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    string: faker.lorem.words(5),
+    stringWithDefault: 'default',
+    nullableString: null,
+    boolean: faker.datatype.boolean(),
+    booleanWithDefault: true,
+    nullableBoolean: null,
+    int: faker.number.int(),
+    intWithDefault: 1,
+    nullableInt: null,
+    bigInt: faker.number.int(),
+    bigIntWithDefault: 1,
+    nullableBigInt: null,
+    float: faker.number.float(),
+    floatWithDefault: 1.1,
+    nullableFloat: null,
+    dateTime: faker.date.anytime(),
+    dateTimeWithDefault: new Date(),
+    nullableDateTime: null,
+    stringArray: faker.lorem.words(5).split(' '),
+    intArray: [faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int()],
+    bigIntArray: [faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int(),faker.number.int()],
+    floatArray: [faker.number.float(),faker.number.float(),faker.number.float(),faker.number.float(),faker.number.float()],
+    booleanArray: [faker.datatype.boolean(),faker.datatype.boolean(),faker.datatype.boolean(),faker.datatype.boolean(),faker.datatype.boolean()],
+    dateTimeArray: [faker.date.anytime(),faker.date.anytime(),faker.date.anytime(),faker.date.anytime(),faker.date.anytime()],
+    json: {test: faker.lorem.word()},
+    jsonWithDefault: {},
+    jsonWithDefaultAndFake: {test2: faker.lorem.word()},
+    nullableJson: null,
+    enum: faker.helpers.arrayElement([Enum.A, Enum.B, Enum.C] as const),
+    enumWithDefault: Enum.A,
+    nullableEnum: null,
+    enums: [Enum.A],
+  };
+}
+export function fakeUser2Complete() {
+  return {
+    id: faker.number.int(),
+  };
+}
+export function fakeUserRelationComplete() {
+  return {
+    id: faker.string.uuid(),
+    userId: faker.string.uuid(),
+    userId2: faker.string.uuid(),
+  };
+}
+export function fakeUser2RelationComplete() {
+  return {
+    id: faker.string.uuid(),
+    user2Id: faker.number.int(),
+  };
+}
+"
+`;
+
 exports[`createMethods with extraExport 1`] = `
 "import { Enum } from '@prisma/client';
 import { faker } from '@faker-js/faker';

--- a/src/__tests__/createMethods.test.ts
+++ b/src/__tests__/createMethods.test.ts
@@ -40,3 +40,17 @@ test('createMethods with `null` as `emptyValueAs`', async () => {
     await createMethods(sampleDMMF.datamodel, undefined, undefined, 'null'),
   ).toMatchSnapshot();
 });
+
+test('createMethods with default clientImportPath', async () => {
+  const sampleDMMF = await getSampleDMMF();
+  expect(
+    await createMethods(sampleDMMF.datamodel, undefined, undefined, 'null', undefined),
+  ).toMatchSnapshot();
+});
+
+test('createMethods with custom clientImportPath', async () => {
+  const sampleDMMF = await getSampleDMMF();
+  expect(
+    await createMethods(sampleDMMF.datamodel, undefined, undefined, 'null', './src/generated/client'),
+  ).toMatchSnapshot();
+});

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,6 +1,7 @@
 import { generatorHandler, GeneratorOptions } from '@prisma/generator-helper';
 import { GENERATOR_NAME } from './constants';
 import { createMethods } from './helpers/createMethods';
+import { extractClientPath } from './utils/generatorUtils';
 import { writeFileSafely } from './utils/writeFileSafely';
 import invariant from 'tiny-invariant';
 
@@ -36,6 +37,7 @@ generatorHandler({
       options.generator.config.extraImport as string | undefined,
       options.generator.config.extraExport as string | undefined,
       options.generator.config.emptyValueAs as string | undefined,
+      extractClientPath(options),
     );
 
     await writeFileSafely(options.generator.output?.value!, fakeMethods);

--- a/src/helpers/createMethods.ts
+++ b/src/helpers/createMethods.ts
@@ -161,6 +161,7 @@ export async function createMethods(
   extraImport?: string,
   extraExport?: string,
   emptyValueAs = 'undefined',
+  clientImportPath: string = '@prisma/client',
 ) {
   const functions: string[] = [];
 
@@ -169,7 +170,7 @@ export async function createMethods(
     createFakeFunctionsWithFKs(models, m, enums, functions, emptyValueAs);
   });
   const enumNames = enums.map((it) => it.name).join(', ');
-  return await `import { ${enumNames} } from '@prisma/client';
+  return await `import { ${enumNames} } from '${clientImportPath}';
 import { faker } from '@faker-js/faker';
 ${extraImport || ''}
 ${extraExport || ''}

--- a/src/utils/generatorUtils.ts
+++ b/src/utils/generatorUtils.ts
@@ -1,0 +1,5 @@
+import { GeneratorOptions } from '@prisma/generator-helper';
+
+export function extractClientPath(options: GeneratorOptions) {
+  return options.otherGenerators.find((g) => g?.provider?.value === 'prisma-client-js')?.output?.value || undefined;
+}


### PR DESCRIPTION
The import path in the generated output assumes the Prisma client will always exist in the default location. But the Prisma client config allows users to specify a [different output location](https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/generating-prisma-client#the-location-of-prisma-client):
```hcl
generator client {
  provider = "prisma-client-js"
  output   = "../src/generated/client"
}
```
This change checks for the optional `output` value and uses it in the generated import path instead if it exists. Otherwise it defaults to the current behavior.