### PR TITLE
fix: emit JSON field faker calls as code strings to prevent regenerat…

### DIFF
--- a/src/helpers/createMethods.ts
+++ b/src/helpers/createMethods.ts
@@ -244,14 +244,5 @@ function createFakeFunctionsWithFKs(
 }
 
 function generateRandomJson(): string {
-  const obj = {
-    foo: faker.string.uuid(),
-    bar: faker.number.int(),
-    bike: faker.number.hex(),
-    a: faker.string.alphanumeric(),
-    b: faker.number.float(),
-    name: faker.person.firstName(),
-    prop: faker.string.binary(),
-  };
-  return JSON.stringify(obj);
+  return '{ foo: faker.string.uuid(), bar: faker.number.int(), bike: faker.number.hex(), a: faker.string.alphanumeric(), b: faker.number.float(), name: faker.person.firstName(), prop: faker.string.binary() }';
 }


### PR DESCRIPTION
Not sure if it aligns with the project. I usually commit the generated prisma artifacts so it's less step to setup the project, and also less step in CICD, adding containers to the mix and it really feels better to commit them. After each test, the test db resets which regenerates the fakes.ts. TL;DR: I'd like fakes.ts to be stable, so git won't detect every regenerated version as a change. The only changing parts are the json values.